### PR TITLE
Fix the movement bug

### DIFF
--- a/packages/common-types/actors.tsx
+++ b/packages/common-types/actors.tsx
@@ -1,6 +1,7 @@
 import * as z from "zod";
 import { v4 as uuid } from "uuid";
 import { pipe } from "effect";
+import { WINDOW_X_CENTER, WINDOW_Y_CENTER } from "./window";
 
 export namespace Pos {
   const RANDOM_MINIMUM_DEVIATION = 20;
@@ -22,8 +23,8 @@ export namespace Pos {
       },
       ({ angle, radius: radius }): Type => ({
         pos: {
-          x: 500 + radius * Math.sin(angle),
-          y: 500 + radius * Math.cos(angle),
+          x: WINDOW_X_CENTER + radius * Math.sin(angle),
+          y: WINDOW_Y_CENTER + radius * Math.cos(angle),
         },
       })
     );

--- a/packages/common-types/actors.tsx
+++ b/packages/common-types/actors.tsx
@@ -87,7 +87,7 @@ export namespace Robot {
     };
 
     export namespace Step {
-      const ROBOT_SPEED = 0.06; // unit / milliseconds
+      const ROBOT_SPEED = 0.5; // unit / milliseconds
       const WATERING_DURATION = 1000; // milliseconds
 
       export const step = (robot: Type) => {
@@ -114,7 +114,6 @@ export namespace Robot {
             x: from.pos.x + currentDist * Math.cos(angle),
             y: from.pos.y + currentDist * Math.sin(angle),
           }));
-          task.from = { pos: robot.pos };
           return;
         }
 

--- a/packages/common-types/actors.tsx
+++ b/packages/common-types/actors.tsx
@@ -22,8 +22,8 @@ export namespace Pos {
       },
       ({ angle, radius: radius }): Type => ({
         pos: {
-          x: radius * Math.sin(angle),
-          y: radius * Math.cos(angle),
+          x: 500 + radius * Math.sin(angle),
+          y: 500 + radius * Math.cos(angle),
         },
       })
     );
@@ -86,7 +86,7 @@ export namespace Robot {
     };
 
     export namespace Step {
-      const ROBOT_SPEED = 0.006; // unit / milliseconds
+      const ROBOT_SPEED = 0.06; // unit / milliseconds
       const WATERING_DURATION = 1000; // milliseconds
 
       export const step = (robot: Type) => {
@@ -101,6 +101,7 @@ export namespace Robot {
 
       export const moveToCoord = (robot: Type, task: Task.MoveToCoordinate) => {
         const { from, to, start } = task;
+        console.log(task);
         const deltaX = to.pos.x - from.pos.x;
         const deltaY = to.pos.y - from.pos.y;
         const totalDist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
@@ -112,6 +113,7 @@ export namespace Robot {
             x: from.pos.x + currentDist * Math.cos(angle),
             y: from.pos.y + currentDist * Math.sin(angle),
           }));
+          task.from = { pos: robot.pos };
           return;
         }
 

--- a/packages/common-types/actors.tsx
+++ b/packages/common-types/actors.tsx
@@ -102,7 +102,6 @@ export namespace Robot {
 
       export const moveToCoord = (robot: Type, task: Task.MoveToCoordinate) => {
         const { from, to, start } = task;
-        console.log(task);
         const deltaX = to.pos.x - from.pos.x;
         const deltaY = to.pos.y - from.pos.y;
         const totalDist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);

--- a/packages/common-types/window.ts
+++ b/packages/common-types/window.ts
@@ -1,0 +1,5 @@
+export const WINDOW_X_SIZE = 1000;
+export const WINDOW_Y_SIZE = 1000;
+
+export const WINDOW_X_CENTER = WINDOW_X_SIZE / 2;
+export const WINDOW_Y_CENTER = WINDOW_Y_SIZE / 2;

--- a/packages/simulation-server/src/simulation.tsx
+++ b/packages/simulation-server/src/simulation.tsx
@@ -7,6 +7,7 @@ import {
   WaterPump,
 } from "../../common-types/actors";
 import { sleep } from "systemic-ts-utils/async-utils";
+import { WINDOW_X_CENTER, WINDOW_Y_CENTER } from "../../common-types/window";
 
 export type Simulation = ReturnType<(typeof Simulation)["make"]>;
 export namespace Simulation {
@@ -24,7 +25,11 @@ export namespace Simulation {
           robot: () => addActor(Robot.make({ pos: Pos.makeRandom(250) })),
           sensor: () => addActor(Sensor.make({ pos: Pos.makeRandom(250) })),
           waterPump: () =>
-            addActor(WaterPump.make({ pos: { pos: { x: 500, y: 500 } } })),
+            addActor(
+              WaterPump.make({
+                pos: { pos: { x: WINDOW_X_CENTER, y: WINDOW_Y_CENTER } },
+              })
+            ),
         };
 
         const tickRate = 30;

--- a/packages/simulation-server/src/simulation.tsx
+++ b/packages/simulation-server/src/simulation.tsx
@@ -21,10 +21,10 @@ export namespace Simulation {
         };
 
         const add = {
-          robot: () => addActor(Robot.make({ pos: Pos.makeRandom() })),
-          sensor: () => addActor(Sensor.make({ pos: Pos.makeRandom() })),
+          robot: () => addActor(Robot.make({ pos: Pos.makeRandom(250) })),
+          sensor: () => addActor(Sensor.make({ pos: Pos.makeRandom(250) })),
           waterPump: () =>
-            addActor(WaterPump.make({ pos: { pos: { x: 0, y: 0 } } })),
+            addActor(WaterPump.make({ pos: { pos: { x: 500, y: 500 } } })),
         };
 
         const tickRate = 30;

--- a/packages/simulation-visual/src/App.tsx
+++ b/packages/simulation-visual/src/App.tsx
@@ -16,7 +16,6 @@ export const App = () => {
   const selector = VaettirReact.useOwned(() => Selector(visualizer));
   const assumer = VaettirReact.useOwned(() => ActorAssumer(SERVER));
   const simulationRef = useRef<HTMLDivElement>(null);
-  const dimension = visualizer.api.frame();
   const coords = visualizer.api.coords();
 
   useEffect(() => {
@@ -27,16 +26,7 @@ export const App = () => {
     const setFrameContainerPos = () => {
       const elem = simulationRef.current;
       if (!elem) return;
-      const { clientLeft, clientTop, clientHeight, clientWidth } = elem;
-      const bounding = elem.getBoundingClientRect();
-      visualizer.api.setFrameContainerPos({
-        x: clientLeft,
-        y: clientTop,
-        width: clientWidth,
-        height: clientHeight,
-        boundingX: bounding.x,
-        boundingY: bounding.y,
-      });
+      visualizer.api.setFrameContainerPos();
     };
 
     window.addEventListener("resize", setFrameContainerPos);
@@ -56,7 +46,12 @@ export const App = () => {
             <div
               ref={simulationRef}
               className={cls(styles.simulation)}
-              style={{ width: dimension.x, height: dimension.y }}
+              style={{
+                width: 1000,
+                maxWidth: 1000,
+                height: 1000,
+                maxHeight: 1000,
+              }}
             >
               {coords.map((coord) => (
                 <ActorView key={coord.actor.id} actorCoord={coord} />

--- a/packages/simulation-visual/src/App.tsx
+++ b/packages/simulation-visual/src/App.tsx
@@ -8,6 +8,7 @@ import { ActorAssumer, ActorAssumerCtx } from "./worker/assume";
 import { ActorView } from "./ActorView";
 import { AssumeView } from "./AssumeView";
 import { Selector, SelectorCtx } from "./worker/selector";
+import { WINDOW_X_SIZE, WINDOW_Y_SIZE } from "../../common-types/window";
 
 const SERVER = "http://localhost:3000";
 
@@ -47,10 +48,10 @@ export const App = () => {
               ref={simulationRef}
               className={cls(styles.simulation)}
               style={{
-                width: 1000,
-                maxWidth: 1000,
-                height: 1000,
-                maxHeight: 1000,
+                width: WINDOW_X_SIZE,
+                maxWidth: WINDOW_X_SIZE,
+                height: WINDOW_Y_SIZE,
+                maxHeight: WINDOW_Y_SIZE,
               }}
             >
               {coords.map((coord) => (

--- a/packages/simulation-visual/src/AssumeView.tsx
+++ b/packages/simulation-visual/src/AssumeView.tsx
@@ -166,12 +166,8 @@ export const AssumeControlRobotMoveTo = (props: {
   const visualizer = VisualizerCtx.borrow();
   useEffect(() => {
     const captureClick = (e: MouseEvent) => {
-      const { screenX: x, screenY: y } = e;
-      const simCoord = visualizer.api.viewportCoordinateToMapCoordinate({
-        x,
-        y,
-      });
-      props.onExec(simCoord);
+      console.log(e);
+      props.onExec({ x: e.x, y: e.y });
       window.removeEventListener("mousedown", captureClick);
     };
     window.addEventListener("mousedown", captureClick);

--- a/packages/simulation-visual/src/AssumeView.tsx
+++ b/packages/simulation-visual/src/AssumeView.tsx
@@ -166,7 +166,6 @@ export const AssumeControlRobotMoveTo = (props: {
   const visualizer = VisualizerCtx.borrow();
   useEffect(() => {
     const captureClick = (e: MouseEvent) => {
-      console.log(e);
       props.onExec({ x: e.x, y: e.y });
       window.removeEventListener("mousedown", captureClick);
     };

--- a/packages/simulation-visual/src/sim.module.scss
+++ b/packages/simulation-visual/src/sim.module.scss
@@ -10,8 +10,8 @@
   overflow-x: auto;
 
   .simulation {
-    min-width: 100%;
-    max-width: 100%;
+    min-width: 1000px;
+    max-width: 1000px;
     background-color: white;
   }
 

--- a/packages/simulation-visual/src/worker/visualizer.tsx
+++ b/packages/simulation-visual/src/worker/visualizer.tsx
@@ -5,8 +5,11 @@ import { BoolLock } from "systemic-ts-utils/lock";
 import { sleep } from "systemic-ts-utils/async-utils";
 import { Effect, Exit } from "effect";
 import { getAllActors } from "../../../common-types/client";
-
-const ZOOM = 1;
+import {
+  WINDOW_X_CENTER,
+  WINDOW_X_SIZE,
+  WINDOW_Y_SIZE,
+} from "../../../common-types/window";
 
 export const VisualizerCtx = VaettirReact.Context.make<Visualizer>();
 
@@ -26,7 +29,10 @@ export const Visualizer = (SERVER: string) =>
         measurements: {
           fromViewport: { x: 0, y: 0 } as Pos.Type["pos"],
           containerPos: { x: 0, y: 0 } as Pos.Type["pos"],
-          containerDimension: { x: 1000, y: 1000 } as Pos.Type["pos"],
+          containerDimension: {
+            x: WINDOW_X_SIZE,
+            y: WINDOW_Y_SIZE,
+          } as Pos.Type["pos"],
           frameUnscaled: { x: 0, y: 0 } as Pos.Type["pos"],
           frameScaled: { x: 0, y: 0 } as Pos.Type["pos"],
           frameScaledAndPadded: { x: 0, y: 0 } as Pos.Type["pos"],
@@ -43,11 +49,14 @@ export const Visualizer = (SERVER: string) =>
             if (Exit.isSuccess(lastFetch)) {
               data.actors = lastFetch.value;
 
-              data.measurements.frameUnscaled = { x: 1000, y: 1000 };
+              data.measurements.frameUnscaled = {
+                x: WINDOW_X_SIZE,
+                y: WINDOW_Y_SIZE,
+              };
 
               data.measurements.frameScaled = {
-                x: data.measurements.frameUnscaled.x * 2 * ZOOM,
-                y: data.measurements.frameUnscaled.y * 2 * ZOOM,
+                x: data.measurements.frameUnscaled.x * 2,
+                y: data.measurements.frameUnscaled.y * 2,
               };
 
               data.measurements.frameScaledAndPadded = {
@@ -55,7 +64,7 @@ export const Visualizer = (SERVER: string) =>
                 y: data.measurements.frameScaled.y,
               };
 
-              data.measurements.xCenteringDiff = 500;
+              data.measurements.xCenteringDiff = WINDOW_X_CENTER;
             }
 
             channels.change.emit();
@@ -76,8 +85,8 @@ export const Visualizer = (SERVER: string) =>
         (data.actors || []).map((actor) => ({
           actor,
           pos: {
-            x: actor.pos.x * ZOOM,
-            y: actor.pos.y * ZOOM,
+            x: actor.pos.x,
+            y: actor.pos.y,
           },
         }));
 
@@ -93,16 +102,19 @@ export const Visualizer = (SERVER: string) =>
           y: pos.y - center.y,
         };
         const descaled = {
-          x: relativeToCenter.x / ZOOM,
-          y: relativeToCenter.y / ZOOM,
+          x: relativeToCenter.x,
+          y: relativeToCenter.y,
         };
         return descaled;
       };
 
       const setFrameContainerPos = () => {
-        data.measurements.containerDimension = { x: 1000, y: 1000 };
+        data.measurements.containerDimension = {
+          x: WINDOW_X_SIZE,
+          y: WINDOW_Y_SIZE,
+        };
         data.measurements.containerPos = { x: 0, y: 0 };
-        data.measurements.fromViewport = { x: 1000, y: 1000 };
+        data.measurements.fromViewport = { x: WINDOW_X_SIZE, y: WINDOW_Y_SIZE };
       };
 
       return {


### PR DESCRIPTION
To fix the bug I drastically simplified all math by assuming a fixed game window size of 1000x1000.
This way, the screen size doesn't change, which was one of the things complicating the translation math.

From there, the rest of the math also gets drastically simpler as we can just use the viewport click coordinates instead of translating them.

Afterwards it was just a matter of fixing the simulation code, including the spawning mechanism.

There's still a React lint going on that I don't quite get, so I'll need help on that

https://github.com/Kelerchian/ax-autofarming-demo-simulator/assets/15343819/eeab8eac-47e0-4d23-b4da-5b2e4dbb1441

